### PR TITLE
Rename configure script

### DIFF
--- a/configuration.ccl
+++ b/configuration.ccl
@@ -2,7 +2,7 @@
 
 PROVIDES Boost
 {
-  SCRIPT Boost.sh
+  SCRIPT configure.sh
   LANG bash
   OPTIONS BOOST_DIR
 }

--- a/configure.sh
+++ b/configure.sh
@@ -71,7 +71,7 @@ if [ -z "${BOOST_DIR}" ]; then
     set -e                      # Abort on errors
     cd ${SCRATCH_BUILD}
     if [ -e ${DONE_FILE} -a ${DONE_FILE} -nt ${SRCDIR}/dist/${NAME}.tar.gz \
-                         -a ${DONE_FILE} -nt ${SRCDIR}/Boost.sh ]
+                         -a ${DONE_FILE} -nt ${SRCDIR}/configure.sh ]
     then
         echo "Boost: The enclosed Boost library has already been built; doing nothing"
     else


### PR DESCRIPTION
We decided to rename all configure scripts to "configure._", instead of "THORNNAME._".
